### PR TITLE
Use rsync --recursive instead or rsync -a for deletes.

### DIFF
--- a/conda/gateways/disk/delete.py
+++ b/conda/gateways/disk/delete.py
@@ -89,7 +89,7 @@ def rmtree(path, *args, **kwargs):
         if rsync and isdir('.empty'):
             try:
                 out = check_output(
-                    [rsync, '-a', '--force', '--delete', join(getcwd(), '.empty') + "/",
+                    [rsync, '--recursive', '--force', '--delete', join(getcwd(), '.empty') + "/",
                      path + "/"],
                     stderr=STDOUT)
             except CalledProcessError:


### PR DESCRIPTION
rsync -a aka rsync --archive is an alias for rsync -rlptgoD, which in long form are --recursive --links --perms --time --groups --owner --devices. When .empty is in fact an empty directory created by conda immediately before rsyncing, these two commands are equivalent.

When there is already an empty .empty directory before conda runs, groups owner and perms are copied over from the existing directory to the target directory that is being emptied, which can cause problems if the .empty file was not created by the same user.

If the .empty directory is not actually empty, --devices and --links will cause more content to be copied than otherwise would when they are not used, and --devices in particular (if running as super user) can cause side effects that would not ordinarily be associated with simply copying files or especially with simply removing them.